### PR TITLE
Manual past due date for task

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -16,6 +16,7 @@
             "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
+            "elm-community/json-extra": "4.3.0",
             "feathericons/elm-feather": "1.5.0",
             "jmpavlick/elm-ui-markdown": "1.0.0",
             "justinmimbs/date": "3.2.1",
@@ -33,7 +34,8 @@
             "elm/svg": "1.0.1",
             "elm/virtual-dom": "1.0.3",
             "elm-community/result-extra": "2.4.0",
-            "rtfeldman/elm-hex": "1.0.0"
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         }
     },
     "test-dependencies": {

--- a/public/demo-data.json
+++ b/public/demo-data.json
@@ -7,6 +7,7 @@
       "period": 25,
       "bitTags": 0,
       "type": "",
+      "manualPastDueDate": "",
       "completionEntries": [
         {
           "year": 2023,
@@ -30,6 +31,7 @@
       "period": 60,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": "",
       "completionEntries": [
         {
           "year": 2023,
@@ -51,6 +53,7 @@
         "seasonStart": 34,
         "seasonDuration": 90
       },
+      "manualPastDueDate": "",
       "bitTags": 2,
       "completionEntries": [
         {
@@ -74,6 +77,7 @@
         "seasonStart": 150,
         "seasonDuration": 90
       },
+      "manualPastDueDate": {},
       "completionEntries": [
         {
           "year": 2023,
@@ -93,6 +97,7 @@
       "period": 30,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": {},
       "completionEntries": [
         {
           "year": 2023,
@@ -108,6 +113,7 @@
       "period": 300,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": {},
       "completionEntries": [
         {
           "year": 2022,
@@ -126,6 +132,10 @@
         "seasonStart": 130,
         "seasonDuration": 200
       },
+      "manualPastDueDate": {
+        "year": 2024,
+        "day": 300
+      },
       "completionEntries": [
         {
           "year": 2023,
@@ -141,6 +151,7 @@
       "period": 200,
       "bitTags": 1,
       "type": null,
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -156,6 +167,7 @@
       "period": 200,
       "bitTags": 1,
       "type": {},
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -174,6 +186,7 @@
         "seasonStart": 150,
         "seasonDuration": 100
       },
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2021,
@@ -189,6 +202,7 @@
       "period": 180,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -207,6 +221,7 @@
         "seasonStart": 150,
         "seasonDuration": 150
       },
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -226,6 +241,7 @@
       "period": 150,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -241,6 +257,7 @@
       "period": 180,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -259,6 +276,7 @@
         "seasonStart": 85,
         "seasonDuration": 260
       },
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -282,6 +300,7 @@
       "period": 15,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -301,6 +320,7 @@
       "period": 60,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -320,6 +340,7 @@
       "period": 365,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -335,6 +356,7 @@
       "period": 300,
       "bitTags": 1,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -350,6 +372,7 @@
       "period": 200,
       "bitTags": 4,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,
@@ -365,6 +388,7 @@
       "period": 500,
       "bitTags": 2,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2021,
@@ -380,6 +404,7 @@
       "period": 40,
       "bitTags": 0,
       "type": "",
+      "manualPastDueDate": null,
       "completionEntries": [
         {
           "year": 2023,

--- a/src/LunarTask.elm
+++ b/src/LunarTask.elm
@@ -70,6 +70,7 @@ type alias LunarTask =
     , bitTags : Int
     , completionEntries : List Date.Date
     , taskType : AllYearOrSeasonal
+    , customPastDueDate : Maybe Date.Date
     }
 
 
@@ -436,7 +437,12 @@ entryInfoToDate info =
 -- Mocked Data
 
 
-genTaskWithOptions : { entries : List Date.Date, period : Int } -> LunarTask
+genTaskWithOptions :
+    { entries : List Date.Date
+    , period : Int
+    , customPastDueDate : Maybe Date.Date
+    }
+    -> LunarTask
 genTaskWithOptions opts =
     { taskOwner = "1234567"
     , title = "task"
@@ -446,6 +452,7 @@ genTaskWithOptions opts =
     , period = opts.period
     , completionEntries = opts.entries
     , taskType = AllYear
+    , customPastDueDate = opts.customPastDueDate
     }
 
 

--- a/src/LunarTask.elm
+++ b/src/LunarTask.elm
@@ -28,7 +28,8 @@ module LunarTask exposing
 import Date exposing (Date, Interval(..), Unit(..))
 import Html exposing (th)
 import Http exposing (task)
-import Json.Decode as Decode exposing (Decoder, field, int, map2, map7, map8, oneOf, string)
+import Json.Decode as Decode exposing (Decoder, field, int, map2, oneOf, string)
+import Json.Decode.Extra exposing (andMap)
 import Json.Encode as Encode
 import List exposing (length)
 
@@ -70,7 +71,7 @@ type alias LunarTask =
     , bitTags : Int
     , completionEntries : List Date.Date
     , taskType : AllYearOrSeasonal
-    , customPastDueDate : Maybe Date.Date
+    , manualPastDueDate : Maybe Date.Date
     }
 
 
@@ -181,11 +182,26 @@ getDaysPastDue currentDate task =
 
         dateDiff =
             Date.diff Days lastCompletedAt currentDate
+
+        manualPastDueDate =
+            Maybe.withDefault (Date.fromOrdinalDate 1990 1)
+                task.manualPastDueDate
+
+        manualPastDueDateDiff =
+            Date.diff Days manualPastDueDate currentDate
     in
-    [ dateDiff - task.period ]
-        |> (::) 0
-        |> List.maximum
-        |> Maybe.withDefault 0
+    case Date.compare manualPastDueDate lastCompletedAt of
+        GT ->
+            [ manualPastDueDateDiff ]
+                |> (::) 0
+                |> List.maximum
+                |> Maybe.withDefault 0
+
+        _ ->
+            [ dateDiff - task.period ]
+                |> (::) 0
+                |> List.maximum
+                |> Maybe.withDefault 0
 
 
 type SeasonalData
@@ -350,6 +366,14 @@ lunarTaskEncoder task =
                         [ ( "seasonStart", Encode.int seasonStart )
                         , ( "seasonEnd", Encode.int seasonEnd )
                         ]
+
+        manualPastDueDateToObject =
+            case task.manualPastDueDate of
+                Nothing ->
+                    Encode.null
+
+                Just date ->
+                    Encode.object <| completionEntryToObject date
     in
     Encode.object
         [ ( "taskOwner", Encode.string task.taskOwner )
@@ -360,20 +384,22 @@ lunarTaskEncoder task =
         , ( "bitTags", Encode.int task.bitTags )
         , ( "completionEntries", Encode.list Encode.object (List.map completionEntryToObject task.completionEntries) )
         , ( "type", allYearOrSeasonalToObject )
+        , ( "manualPastDueDate", manualPastDueDateToObject )
         ]
 
 
 lunarTaskDecoder : Decoder LunarTask
 lunarTaskDecoder =
-    map8 LunarTask
-        (field "taskOwner" string)
-        (field "title" string)
-        (field "notes" string)
-        (field "id" string)
-        (field "period" int)
-        (field "bitTags" int)
-        (field "completionEntries" (Decode.list entryDecoder))
-        (field "type" allYearOrSeasonalDecoder)
+    Decode.succeed LunarTask
+        |> andMap (field "taskOwner" string)
+        |> andMap (field "title" string)
+        |> andMap (field "notes" string)
+        |> andMap (field "id" string)
+        |> andMap (field "period" int)
+        |> andMap (field "bitTags" int)
+        |> andMap (field "completionEntries" (Decode.list entryDecoder))
+        |> andMap (field "type" allYearOrSeasonalDecoder)
+        |> andMap (field "manualPastDueDate" (Decode.maybe entryDecoder))
 
 
 allYearOrSeasonalDecoder : Decoder AllYearOrSeasonal
@@ -440,7 +466,7 @@ entryInfoToDate info =
 genTaskWithOptions :
     { entries : List Date.Date
     , period : Int
-    , customPastDueDate : Maybe Date.Date
+    , manualPastDueDate : Maybe Date.Date
     }
     -> LunarTask
 genTaskWithOptions opts =
@@ -452,7 +478,7 @@ genTaskWithOptions opts =
     , period = opts.period
     , completionEntries = opts.entries
     , taskType = AllYear
-    , customPastDueDate = opts.customPastDueDate
+    , manualPastDueDate = opts.manualPastDueDate
     }
 
 
@@ -476,4 +502,5 @@ lunarTaskWithOneHundredCompletionEntries =
     , period = 20
     , completionEntries = completionEntries
     , taskType = AllYear
+    , manualPastDueDate = Nothing
     }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -387,6 +387,8 @@ type Msg
     | EditSeasonEnd Float
     | EditTaskDisableTag String
     | EditTaskEnableTag String
+    | EditTaskRemoveManualPastDueDate
+    | EditTaskSetManualPastDueDate DatePicker.Msg
     | EditTaskTitle String
     | EditTaskNotes String
     | EditTaskRemoveCompletionEntry Date.Date
@@ -708,6 +710,7 @@ update msg model =
                             , bitTags = 0
                             , taskOwner = "alksdjflasd"
                             , taskType = AllYear
+                            , manualPastDueDate = Nothing
                             }
 
                         originalTask =
@@ -731,6 +734,30 @@ update msg model =
 
                     else
                         ( { model | editedTask = Nothing, view = LoadedTasksView MainTasksView }, Cmd.none )
+
+        EditTaskRemoveManualPastDueDate ->
+            case model.editedTask of
+                Just task ->
+                    ( { model
+                        | editedTask = Just { task | manualPastDueDate = Nothing }
+                      }
+                    , Cmd.none
+                    )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+        EditTaskSetManualPastDueDate datePickerMsg ->
+            case model.editedTask of
+                Just task ->
+                    ( { model
+                        | editedTask = Just { task | manualPastDueDate = Nothing }
+                      }
+                    , Cmd.none
+                    )
+
+                Nothing ->
+                    ( model, Cmd.none )
 
         EditTaskType taskTypeOption ->
             case model.editedTask of

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -14,7 +14,7 @@ import Element.Events exposing (onClick)
 import Element.Font as Font
 import Element.Input as Input exposing (OptionState(..), Thumb, button)
 import FeatherIcons as Icon exposing (Icon, key)
-import Html exposing (Html, td, th, tr)
+import Html exposing (Html, hr, td, th, tr)
 import Html.Attributes exposing (hidden, style, type_, value)
 import Html.Events exposing (onBlur)
 import Http
@@ -1903,21 +1903,21 @@ viewTask model editingNotes =
                 , taskTypeInput
                 , case getUnexpiredManualPastDueDate task.manualPastDueDate (getLastCompletedAt task) of
                     Just date ->
-                        column []
-                            [ el [] (text <| "Task will be marked as past due on " ++ Date.toIsoString date)
-                            , el
-                                [ onClick EditTaskRemoveManualPastDueDate
-                                , htmlAttribute <| Html.Attributes.style "cursor" "pointer"
-                                ]
-                                (text "x (clear manual date)")
+                        row []
+                            [ el [ Font.bold ] (text <| "Task is manually set to be past due on " ++ Date.toIsoString date)
+                            , text " -- "
+                            , button []
+                                { onPress = Just EditTaskRemoveManualPastDueDate
+                                , label = Icon.trash2 |> Icon.toHtml [] |> Element.html
+                                }
                             ]
 
                     Nothing ->
                         column []
-                            [ el [ Font.bold ] (text "Override task to be past due on:")
+                            [ el [ Font.bold ] (text "Ignore settings and make past due on")
                             , el [ Border.width 1, paddingXY 10 10, Border.color color.lightGrey ] <|
                                 (DatePicker.view Nothing
-                                    { datePickerSettings | placeholder = "" }
+                                    { datePickerSettings | placeholder = "Manual past due date" }
                                     model.datePickerForManualPastDue
                                     |> Html.map EditTaskSetManualPastDueDate
                                     |> Element.html

--- a/src/NewLunarTask.elm
+++ b/src/NewLunarTask.elm
@@ -101,6 +101,7 @@ newLunarTaskEncoder task =
                 , ( "id", Encode.string (String.fromInt demoData.demoId) )
                 , ( "bitTags", Encode.int 0 )
                 , ( "type", encodedTaskType )
+                , ( "manualPastDueDate", Encode.null )
                 ]
 
         Nothing ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -69,7 +69,34 @@ suite =
             fallOrdinal
     in
     describe "Lunar Tasks"
-        [ describe "getSeasonalData"
+        [ describe "custom past due dates"
+            [ test "overrides tasks calculated past due date" <|
+                \_ ->
+                    let
+                        currentDate =
+                            Date.fromOrdinalDate 2024 fallOrdinal
+
+                        lastCompletedAt =
+                            Date.fromOrdinalDate 2024 springOrdinal
+
+                        customPastDueDate =
+                            Date.add Date.Days 30 currentDate
+
+                        notRecentlyCompletedButWithCustomPastDueDateInFuture =
+                            genTaskWithOptions
+                                { entries = [ lastCompletedAt ]
+                                , period = 5
+                                , customPastDueDate = Just customPastDueDate
+                                }
+                    in
+                    Expect.equal
+                        (LunarTask.pastDue
+                            currentDate
+                            notRecentlyCompletedButWithCustomPastDueDateInFuture
+                        )
+                        False
+            ]
+        , describe "getSeasonalData"
             [ describe "currently summer time of year"
                 [ test "summer task shows as in season" <|
                     \_ ->
@@ -169,6 +196,7 @@ suite =
                         LunarTask.genTaskWithOptions
                             { period = 1
                             , entries = [ Date.fromPosix Time.utc prevTime ]
+                            , customPastDueDate = Nothing
                             }
 
                     ( dayLaterModel, _ ) =
@@ -184,7 +212,7 @@ suite =
                 \_ ->
                     let
                         task =
-                            genTaskWithOptions { period = 10, entries = [] }
+                            genTaskWithOptions { period = 10, entries = [], customPastDueDate = Nothing }
 
                         fourEntries =
                             genEntries 1711211815576 12.2 4
@@ -197,7 +225,7 @@ suite =
                 \_ ->
                     let
                         task =
-                            genTaskWithOptions { period = 10, entries = [] }
+                            genTaskWithOptions { period = 10, entries = [], customPastDueDate = Nothing }
 
                         overFiveEntries =
                             genEntries 1711211815576 15 12


### PR DESCRIPTION
- Override cadence settings with a manual past due date.
- When last completion entry is more recent than the manually set due date, the manually set due date is considered to be expired and task returns to its regular cadence settings.